### PR TITLE
changed getInerOpsData endpoint to retrieve data based on i_Runwithnu…

### DIFF
--- a/src/main/java/org/mskcc/limsrest/limsapi/interops/GetInterOpsDataTask.java
+++ b/src/main/java/org/mskcc/limsrest/limsapi/interops/GetInterOpsDataTask.java
@@ -26,7 +26,7 @@ public class GetInterOpsDataTask extends LimsTask {
         List<Map<String, Object>> interOps = new ArrayList<>();
         try {
             List<DataRecord> interOpsRecords = dataRecordManager.queryDataRecords("Interopsdatum",
-                    "i_Run = '" + runId + "'", user);
+                    "i_Runwithnumberprefixremoved = '" + runId + "'", user);
 
             for (DataRecord interOpsRecord : interOpsRecords) {
                 Map<String, Object> fields = interOpsRecord.getFields(user);
@@ -35,7 +35,6 @@ public class GetInterOpsDataTask extends LimsTask {
         } catch (Exception e) {
             log.error(String.format("Error while retrieving InterOpsDatum for run id: %s", runId), e);
         }
-
         return interOps;
     }
 }


### PR DESCRIPTION
changed getInerOpsData endpoint to retrieve data based on "i_Runwithnumberprefixremoved" field

Hi David and Lisa,

This code is ready. Please review. There are not many changes. It is working on pitchfork igo-qc-dev site. You can test it on the dev site for runs older than 05-24, because tango InterOps data is not updated daily. But I did run the script to push some newer data to tango so that it can be tested to see how it will look.

If you feel that it is good, please feel free to merge and deploy this on production next week. I am off next week. Let me know if you have any questions.

Thanks!
Ajay